### PR TITLE
Further updates to Ladder Encoding

### DIFF
--- a/testing/iris_data/iris_config.json
+++ b/testing/iris_data/iris_config.json
@@ -22,7 +22,8 @@
     {
       "type": "ladder_encode",
       "feature": "size",
-      "order": ["small", "medium", "large"]
+      "order": ["small", "medium", "large"],
+      "min_frequency": 0.3
     },
     {
       "type": "imputation_simple",


### PR DESCRIPTION
Now handles the cases where the features present in the dataset when the Ladder Encoding is done do not perfectly match the order specified by the user (i.e. a feature was dropped due to some other data hook earlier in the pipeline)