### PR TITLE
Ladder Encoder Patch; Handle Infrequent Columns

### DIFF
--- a/data/hooks/encoding.py
+++ b/data/hooks/encoding.py
@@ -1,4 +1,3 @@
-import copy
 from copy import copy as shallow_copy
 from logging import DEBUG, Logger
 from typing import Optional, Self

--- a/data/hooks/encoding.py
+++ b/data/hooks/encoding.py
@@ -206,10 +206,17 @@ class LadderEncoding(FittedDataHook):
         )
         # Have the user define the order of the ladder explicitly;
         #  this needs to provided for a LadderEncode to make sense!
-        self.order = parse_data_config_entry(
-            "order", config,
-            is_list(self.logger)
+        order = parse_data_config_entry(
+            "order", config
         )
+        if type(order) is not list:
+            raise ValueError("Ladder encoding needs a list of ordinal values, in the desired order, to function. "
+                             f"Value of the data config was of type '{type(order)}'.")
+        if len(order) < 2:
+            raise ValueError("To ladder encode data, at least 2 values must be provided in the 'order' argument. "
+                             f"The provided list had {len(order)} value(s) instead.")
+        self.order = order
+
         # We handle min-frequency detection ourselves, to avoid the creation of an "infrequent" column which has no
         #  position in the order
         self.min_frequency = parse_data_config_entry(

--- a/data/hooks/encoding.py
+++ b/data/hooks/encoding.py
@@ -204,10 +204,11 @@ class LadderEncoding(FittedDataHook):
             "feature", config,
             is_not_null(self.logger)
         )
-        # Grab the maximum number of unique values allowed before a column is treated as continuous
+        # Have the user define the order of the ladder explicitly;
+        #  this needs to provided for a LadderEncode to make sense!
         self.order = parse_data_config_entry(
             "order", config,
-            default_as([], self.logger), is_list(self.logger)
+            is_list(self.logger)
         )
         # We handle min-frequency detection ourselves, to avoid the creation of an "infrequent" column which has no
         #  position in the order

--- a/data/hooks/encoding.py
+++ b/data/hooks/encoding.py
@@ -391,7 +391,7 @@ class LadderEncoding(FittedDataHook):
             # Generate the corresponding column's name, but only if we had a prior group (the first col will be dropped)
             col_name = ""
             if prior_group_str is not None:
-                col_name = f"{self.feature} ({prior_group_str} -> {group_str})"
+                col_name = f"{self.feature} ({prior_group_str} <- {group_str})"
 
             # Save this result into the dictionary for later
             ladder_dict[col_name] = rung_val
@@ -405,8 +405,14 @@ class LadderEncoding(FittedDataHook):
         # Drop the first (base) column to avoid a homogenous final column
         ladder_df = ladder_df.iloc[:, 1:]
 
+        # Reverse the column order before applying cumsum
+        ladder_df = ladder_df.iloc[:, ::-1]
+
         # Apply CumSum again to finalize the ladder encoding
         ladder_df = np.cumsum(ladder_df, axis=1)
+
+        # Reverse the column order back to the original
+        ladder_df = ladder_df.iloc[:, ::-1]
 
         # Return the result
         return ladder_df

--- a/data/hooks/encoding.py
+++ b/data/hooks/encoding.py
@@ -317,9 +317,8 @@ class LadderEncoding(FittedDataHook):
         prior_group = None
         ladder_dict = {}
         for c in self.order:
-            # If this column doesn't exist in the OHE, add it to the column group for later column naming
+            # If this column doesn't exist in the OHE, skip it entirely
             if c not in ohe_df.columns:
-                col_group.append(c)
                 continue
 
             # Otherwise, append it to both the column pool and column group


### PR DESCRIPTION
Accounts for an edge case which occurs when the `np.cumsum` trick results in the final column being homogenous. The encoder now detects this, and corrects it by dropping the first available feature in the ordered list provided by the user (making it act as the "starting" class instead).